### PR TITLE
remove RTD ISR pin output setting

### DIFF
--- a/carmel_siryn/carmel_siryn.ino
+++ b/carmel_siryn/carmel_siryn.ino
@@ -5468,7 +5468,7 @@ void enableRTD_DDR1_ISR(void)
   Serial.println(__PRETTY_FUNCTION__);
   #endif
 
-  pinMode(RTD_DDR1_ISR_PIN, INPUT_PULLUP);
+  pinMode(RTD_DDR1_ISR_PIN, INPUT);
   attachInterrupt(digitalPinToInterrupt(RTD_DDR1_ISR_PIN), RTD_DDR1_ISR, FALLING);
 }
 
@@ -5481,7 +5481,7 @@ void disableRTD_DDR1_ISR(void)
   #endif
 
   detachInterrupt(digitalPinToInterrupt(RTD_DDR1_ISR_PIN));
-  pinMode(RTD_DDR1_ISR_PIN, OUTPUT);
+//  pinMode(RTD_DDR1_ISR_PIN, OUTPUT); //do not set as ouput - will cause contention with RDRY pin
 }
 
 


### PR DESCRIPTION
Hey Mike.  Why did you change the state of this pin to be an output?  I don't know if it can explain the funny business we see with RTD reads but it can potentially damage the due or the RTD IC as they are both driving against each other.